### PR TITLE
Fix RBS::DuplicatedDeclarationError

### DIFF
--- a/sig/snaky_hash.rbs
+++ b/sig/snaky_hash.rbs
@@ -1,4 +1,3 @@
 module SnakyHash
-  VERSION: String
   # See the writing guide of rbs: https://github.com/ruby/rbs#guides
 end


### PR DESCRIPTION
We remove the RBS declaration of SnakyHash::VERSION from sig/snaky_hash.rbs because it's already declared in sig/snakey_hash/version.rbs.

This duplicate declaration causes RBS::DuplicatedDeclarationError in projects using snaky_hash.